### PR TITLE
Fix issue with page type filtering breaking modular pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.9.6
+## 08/06/19
+1. [](#bug-fix)
+    * Fixed issue with page type filtering breaking modular pages; this now works for both modular and non-modular pages.
+
+
 # v0.9.5
 ## 02/11/18
 1. [](#feature)

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,14 +1,28 @@
 name: Users Page Ownership
-version: 0.9.5
+version: 0.9.6
 description: Adds user ownership functionality to your pages
 icon: user
 author:
   name: Dalen Catt
   email: dalen@cascadeap.com
   url: http://cascadeap.com
-homepage: https://github.com/Moonlight63/grav-plugin-advanced-admin-users-managment
+homepage: https://github.com/Moonlight63/grav-plugin-users-page-ownership
 keywords: admin, users, managment, plugin
-bug: https://github.com/Moonlight63/grav-plugin-advanced-admin-users-managment/issues
+bug: https://github.com/Moonlight63/grav-plugin-users-page-ownership/issues
 license: MIT
 dependencies:
   - { name: grav, version: '>=1.3.7' }
+
+form:
+  validation: strict
+  fields:
+    enabled:
+      type: toggle
+      label: PLUGIN_ADMIN.PLUGIN_STATUS
+      highlight: 1
+      default: 0
+      options:
+        1: PLUGIN_ADMIN.ENABLED
+        0: PLUGIN_ADMIN.DISABLED
+      validate:
+        type: bool

--- a/users-page-ownership.php
+++ b/users-page-ownership.php
@@ -343,7 +343,7 @@ class TwigUsersOwnership{
     public static function pageTypes(){
         
         $grav = Grav::instance();
-        $types = Pages::types();
+        $types = Pages::pageTypes();
         // First filter by configuration
         $hideTypes = $grav['config']->get('plugins.admin.hide_page_types', []);
         foreach ($hideTypes as $type) {


### PR DESCRIPTION
Resolves #9 by using the context-aware `Pages::pageTypes` method call instead of `Pages::types`.

I've also updated `blueprint.yaml` with the correct project URLs, and added the standard enable/disable toggle switch.

I bumped the version number and updated the changelog, so it should be ready for release once this is merged.